### PR TITLE
Fix: Access after delete

### DIFF
--- a/src/capwap-dp.c
+++ b/src/capwap-dp.c
@@ -551,18 +551,17 @@ static void erl_del_wtp(int arity, ei_x_buff *x_in, ei_x_buff *x_out)
 	rcu_read_lock();
 
 	if ((wtp = find_wtp((struct sockaddr *)&addr)) != NULL) {
-		if (!__delete_wtp(wtp))
-			ei_x_encode_atom(x_out, "failed");
-		else {
-			ei_x_encode_tuple_header(x_out, 2);
-			ei_x_encode_atom(x_out, "ok");
-			ei_x_encode_wtp(x_out, wtp);
+		ei_x_encode_tuple_header(x_out, 2);
+		ei_x_encode_atom(x_out, "ok");
+		ei_x_encode_wtp(x_out, wtp);
+
+		if (!__delete_wtp(wtp)) {
+			log(LOG_CRIT, "del_wtp failed, possible data corruption.");
 		}
 	} else
 		ei_x_encode_atom(x_out, "not_found");
 
 	rcu_read_unlock();
-
 }
 
 static void erl_list_wtp(int arity, ei_x_buff *x_in, ei_x_buff *x_out)
@@ -806,12 +805,12 @@ static void erl_detach_station(int arity, ei_x_buff *x_in, ei_x_buff *x_out)
 	rcu_read_lock();
 
 	if ((sta = find_station(ether)) != NULL) {
+		ei_x_encode_tuple_header(x_out, 2);
+		ei_x_encode_atom(x_out, "ok");
+		ei_x_encode_sta(x_out, sta);
+
 		if (__delete_station(sta) == 0) {
-			ei_x_encode_tuple_header(x_out, 2);
-			ei_x_encode_atom(x_out, "ok");
-			ei_x_encode_sta(x_out, sta);
-		} else {
-			ei_x_encode_atom(x_out, "hash_corrupt");
+			log(LOG_CRIT, "detach_station failed, possible data corruption.");
 		}
 	} else
 		ei_x_encode_atom(x_out, "not_found");

--- a/src/capwap-dp.c
+++ b/src/capwap-dp.c
@@ -310,17 +310,18 @@ static void ei_x_encode_sta(ei_x_buff *x, struct station *sta)
 
 static void ei_x_encode_wtp(ei_x_buff *x, struct client *clnt)
 {
+	struct cds_hlist_node *pos;
 	struct station *sta;
 	struct wlan *wlan;
 
 	ei_x_encode_tuple_header(x, 6);
 	ei_x_encode_sockaddr(x, (struct sockaddr *)&clnt->addr);
-	cds_hlist_for_each_entry_rcu_2(wlan, &clnt->wlans, wlan_list) {
+	cds_hlist_for_each_entry_rcu(wlan, pos, &clnt->wlans, wlan_list) {
 		ei_x_encode_list_header(x, 1);
 		ei_x_encode_wlan(x, wlan);
 	}
 	ei_x_encode_empty_list(x);
-	cds_hlist_for_each_entry_rcu_2(sta, &clnt->stations, wtp_list) {
+	cds_hlist_for_each_entry_rcu(sta, pos, &clnt->stations, wtp_list) {
 		ei_x_encode_list_header(x, 1);
 		ei_x_encode_sta(x, sta);
 	}

--- a/src/worker.c
+++ b/src/worker.c
@@ -1402,6 +1402,7 @@ static int ieee8023_bcast_to_wtps(struct worker *w, uint16_t vlan, const unsigne
 {
 	struct cds_lfht_iter iter;      /* For iteration on hash table */
 	struct client *wtp;
+	struct cds_hlist_node *pos;
 	struct wlan *wlan;
 	struct ieee80211_wbinfo wbinfo[MAX_RADIOS];
 
@@ -1415,7 +1416,7 @@ static int ieee8023_bcast_to_wtps(struct worker *w, uint16_t vlan, const unsigne
 		if (uatomic_read(&wtp->sta_count) == 0)
 			continue;
 
-		cds_hlist_for_each_entry_rcu_2(wlan, &wtp->wlans, wlan_list) {
+		cds_hlist_for_each_entry_rcu(wlan, pos, &wtp->wlans, wlan_list) {
 			if (VLAN_ID(wlan->vlan) != VLAN_ID(vlan))
 				continue;
 


### PR DESCRIPTION
Fix a `access after delete` situation: after the upgrade of the userspace-rcu library (which was caused by the version bump of the Alpine base image) some code paths accessed freed memory.